### PR TITLE
mark Siebert Sie 3, Schempp-Hirth SHK as vintage

### DIFF
--- a/gliderlist.csv
+++ b/gliderlist.csv
@@ -157,7 +157,7 @@ ID,Glider,Model,Manufacturer,Competition Class,Kind,Double Seater,Winglets,Exclu
 159,LS 1-0 FG,LS 1-0 FG,Rolladen-Schneider,Club,GL,,,,,96,96,96,96,96,96,96
 160,Mistral C,Mistral C,Mistral-Flugzeugbau,Club,GL,,,,,96,96,96,96,96,96,96
 161,Phöbus B,Phöbus B,Bölkow,Club,GL,,,,,96,96,96,96,96,96,96
-162,SHK,SHK,Schempp-Hirth,Club,GL,,,,,96,96,96,96,96,96,96
+162,SHK,SHK,Schempp-Hirth,Club,GL,,,,x,96,96,96,96,96,96,96
 163,VSO-10,VSO-10,VSO,Club,GL,,,,,96,96,96,96,96,96,96
 164,Mü 22b,Mü 22b,Akaflieg München,Club,GL,,,,,95,95,95,95,95,95,95
 165,G 102 Astir CS Top,G 102 Astir CS Top,Grob Aircraft,Club,GL,,,,,94,94,94,94,94,94,94
@@ -198,7 +198,7 @@ ID,Glider,Model,Manufacturer,Competition Class,Kind,Double Seater,Winglets,Exclu
 200,SF 27,SF 27 MA,Scheibe-Flugzeugbau,Club,GL,,,,x,86,86,86,86,86,86,86
 201,SF 30,SF 30,Scheibe-Flugzeugbau,Club,GL,,,,x,86,86,86,86,86,86,86
 202,SZD-30 Pirat,SZD-30 Pirat,PZL Bielsko,Club,GL,,,,x,86,86,86,86,86,86,86
-203,Sie-3,Sie-3,Paul Siebert,Club,GL,,,,,86,86,86,86,86,86,86
+203,Sie-3,Sie-3,Paul Siebert,Club,GL,,,,x,86,86,86,86,86,86,86
 204,Solo L 33,Solo L 33,-,Club,GL,,,,,86,86,86,86,86,86,86
 205,Std. Austria,Std. Austria,Schempp-Hirth,Club,GL,,,,x,86,86,86,86,86,86,86
 206,VT-16 Orlic,VT-16 Orlic,-,Club,GL,,,,,86,86,86,86,86,86,86


### PR DESCRIPTION
Siebert Sie 3 and Schempp-Hirth SHK should be considered vintage:

- Sie 3 and SHK had its maiden flights over 50 years ago
- both are made out of wood
- both are in Oldtimer Scorings on other platforms
