### PR TITLE
[GLIDER] add Aviastoitel AC-5 family

### DIFF
--- a/gliderlist.csv
+++ b/gliderlist.csv
@@ -622,3 +622,6 @@ ID,Glider,Model,Manufacturer,Competition Class,Kind,Double Seater,Winglets,Exclu
 633,Swift-Light,Swift-Light E,Aériane,Club,FG,,,,,x,76,76,76,76,76,76,76,76
 634,Swift-Light,Swift-Light,Aériane,Club,GL,,,,,,76,76,76,76,76,76,76,76
 635,Diamant 16.5,Diamant 16.5,FFA,18,GL,,,,,,105,105,105,105,105,105,105,105
+636,AC-5M,AC-5,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
+637,AC-5K,AC-5,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
+638,AC-5Me,AC-5,Aviastroitel,Club,FG,,,,,x,84,84,84,84,84,84,84,84

--- a/gliderlist.csv
+++ b/gliderlist.csv
@@ -622,6 +622,6 @@ ID,Glider,Model,Manufacturer,Competition Class,Kind,Double Seater,Winglets,Exclu
 633,Swift-Light,Swift-Light E,Aériane,Club,FG,,,,,x,76,76,76,76,76,76,76,76
 634,Swift-Light,Swift-Light,Aériane,Club,GL,,,,,,76,76,76,76,76,76,76,76
 635,Diamant 16.5,Diamant 16.5,FFA,18,GL,,,,,,105,105,105,105,105,105,105,105
-636,AC-5M,AC-5,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
-637,AC-5K,AC-5,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
-638,AC-5Me,AC-5,Aviastroitel,Club,FG,,,,,x,84,84,84,84,84,84,84,84
+636,AC-5,AC-5M,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
+637,AC-5,AC-5K,Aviastroitel,Club,MG,,,,,x,84,84,84,84,84,84,84,84
+638,AC-5,AC-5Me,Aviastroitel,Club,FG,,,,,x,84,84,84,84,84,84,84,84


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/Aviastroitel_AC-5M

Index seems to be the same as AC-4 Russia but I removed the vintage checkmark (first flight 1999).